### PR TITLE
feat(ui): Position UI windows by anchor and offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Pass settings to `require('muren').setup`. The current defaults are:
   patterns_height = 10,
   options_width = 20,
   preview_height = 12,
+  -- window positions
+  vertical_anchor = "center", -- "top" | "center" | "bottom
+  horizontal_anchor = "center", -- "left" | "center" | "right"
+  vertical_offset = 0,
+  horizontal_offset = 0,
   -- options order in ui
   order = {
     'buffer',

--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Pass settings to `require('muren').setup`. The current defaults are:
   options_width = 20,
   preview_height = 12,
   -- window positions
-  vertical_anchor = "center", -- "top" | "center" | "bottom
-  horizontal_anchor = "center", -- "left" | "center" | "right"
-  vertical_offset = 0,
+  vertical_anchor = nil, -- "top" | "bottom", else row is centered
+  horizontal_anchor = nil, -- "left" | "right", else col is centered
+  vertical_offset = 0,  -- offsets are relative to anchors
   horizontal_offset = 0,
   -- options order in ui
   order = {

--- a/README.md
+++ b/README.md
@@ -76,6 +76,15 @@ You can also access this using lua as the following functions:
 * `require('muren.api').open_fresh_ui`
 * `require('muren.api').open_unique_ui`
 
+Muren's commands and exposed functions take optional arguments to position the ui windows by anchor and offset (command completion available), e.g.:
+
+`:MurenOpen top` or
+`:MurenToggle top_left 5 10` (anchor, vertical offset, horizontal offset)
+
+```lua
+require('muren.api').open_ui({anchor = "top_left", vertical_offset = 5, horizontal_offset = 10})
+```
+
 ## Configuration
 Pass settings to `require('muren').setup`. The current defaults are:
 ```lua
@@ -109,8 +118,8 @@ Pass settings to `require('muren').setup`. The current defaults are:
   options_width = 20,
   preview_height = 12,
   -- window positions
-  vertical_anchor = nil, -- "top" | "bottom", else row is centered
-  horizontal_anchor = nil, -- "left" | "right", else col is centered
+  anchor = 'center', -- Set to one of:
+  -- 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top_left' | 'top_right' | 'bottom_left' | 'bottom_right'
   vertical_offset = 0,  -- offsets are relative to anchors
   horizontal_offset = 0,
   -- options order in ui

--- a/lua/muren.lua
+++ b/lua/muren.lua
@@ -24,13 +24,15 @@ M.setup = function(opts)
     MurenUnique = { api.open_unique_ui, true },
   }
 
-
   local create_muren_commands = function()
     for name, muren_cmd in pairs(muren_commands) do
       local muren_api, range = unpack(muren_cmd)
       vim.api.nvim_create_user_command(name, function(args)
         local anchor, vertical_offset, horizontal_offset = unpack(args.fargs)
         muren_api({
+          range = args.range,
+          line1 = args.line1,
+          line2 = args.line2,
           anchor = anchor,
           vertical_offset = vertical_offset,
           horizontal_offset = horizontal_offset,

--- a/lua/muren.lua
+++ b/lua/muren.lua
@@ -10,45 +10,42 @@ M.anchor_positions = {
   'bottom_left',
   'bottom_right',
 }
+local api = require('muren.api')
+local muren_commands = {
+  MurenOpen = api.open_ui,
+  MurenClose = api.close_ui,
+  MurenToggle = api.toggle_ui,
+  MurenFresh = api.open_fresh_ui,
+  MurenUnique = api.open_unique_ui,
+}
 
-M.setup = function(opts)
-  local options = require('muren.options')
-  options.update(opts or {})
-
-  local api = require('muren.api')
-  local muren_commands = {
-    MurenOpen = { api.open_ui, true },
-    MurenClose = { api.close_ui, nil },
-    MurenToggle = { api.toggle_ui, true },
-    MurenFresh = { api.open_fresh_ui, true },
-    MurenUnique = { api.open_unique_ui, true },
-  }
-
-  local create_muren_commands = function()
-    for name, muren_cmd in pairs(muren_commands) do
-      local muren_api, range = unpack(muren_cmd)
-      vim.api.nvim_create_user_command(name, function(args)
-        local anchor, vertical_offset, horizontal_offset = unpack(args.fargs)
-        muren_api({
-          range = args.range,
-          line1 = args.line1,
-          line2 = args.line2,
-          anchor = anchor,
-          vertical_offset = vertical_offset,
-          horizontal_offset = horizontal_offset,
-        })
-      end, {
+local create_muren_commands = function()
+  for name, muren_api in pairs(muren_commands) do
+    vim.api.nvim_create_user_command(name, function(args)
+      local anchor, vertical_offset, horizontal_offset = unpack(args.fargs)
+      muren_api({
+        range = args.range,
+        line1 = args.line1,
+        line2 = args.line2,
+        anchor = anchor,
+        vertical_offset = vertical_offset,
+        horizontal_offset = horizontal_offset,
+      })
+    end, {
         nargs = '*',
-        range = range,
+        range = true,
         complete = function()
           local cmdline = vim.fn.getcmdline()
           local _, space_count = string.gsub(cmdline, ' ', '')
           return space_count == 1 and M.anchor_positions or {}
         end,
       })
-    end
   end
+end
 
+M.setup = function(opts)
+  local options = require('muren.options')
+  options.update(opts or {})
   if options.default.create_commands then
     create_muren_commands()
   end

--- a/lua/muren.lua
+++ b/lua/muren.lua
@@ -1,17 +1,54 @@
 local M = {}
 
+M.anchor_positions = {
+  'top',
+  'bottom',
+  'left',
+  'right',
+  'top_left',
+  'top_right',
+  'bottom_left',
+  'bottom_right',
+}
 
 M.setup = function(opts)
   local options = require('muren.options')
   options.update(opts or {})
 
+  local api = require('muren.api')
+  local muren_commands = {
+    MurenOpen = { api.open_ui, true },
+    MurenClose = { api.close_ui, nil },
+    MurenToggle = { api.toggle_ui, true },
+    MurenFresh = { api.open_fresh_ui, true },
+    MurenUnique = { api.open_unique_ui, true },
+  }
+
+
+  local create_muren_commands = function()
+    for name, muren_cmd in pairs(muren_commands) do
+      local muren_api, range = unpack(muren_cmd)
+      vim.api.nvim_create_user_command(name, function(args)
+        local anchor, vertical_offset, horizontal_offset = unpack(args.fargs)
+        muren_api({
+          anchor = anchor,
+          vertical_offset = vertical_offset,
+          horizontal_offset = horizontal_offset,
+        })
+      end, {
+        nargs = '*',
+        range = range,
+        complete = function()
+          local cmdline = vim.fn.getcmdline()
+          local _, space_count = string.gsub(cmdline, ' ', '')
+          return space_count == 1 and M.anchor_positions or {}
+        end,
+      })
+    end
+  end
+
   if options.default.create_commands then
-    local api = require('muren.api')
-    vim.api.nvim_create_user_command('MurenOpen', api.open_ui, {range = true})
-    vim.api.nvim_create_user_command('MurenClose', api.close_ui, {})
-    vim.api.nvim_create_user_command('MurenToggle', api.toggle_ui, {range = true})
-    vim.api.nvim_create_user_command('MurenFresh', api.open_fresh_ui, {range = true})
-    vim.api.nvim_create_user_command('MurenUnique', api.open_unique_ui, {range = true})
+    create_muren_commands()
   end
 end
 

--- a/lua/muren/api.lua
+++ b/lua/muren/api.lua
@@ -1,7 +1,21 @@
 local M = {}
 
+local get_range = function(opts)
+  local range
+  if opts.range == 2 then
+    range = {start = opts.line1, _end = opts.line2}
+  end
+  return range
+end
+
+local get_opts = function(opts)
+  opts = opts or {}
+  opts.range = get_range(opts)
+  return opts
+end
+
 M.open_ui = function(opts)
-  require('muren.ui').open(opts)
+  require('muren.ui').open(get_opts(opts))
 end
 
 M.close_ui = function()
@@ -9,17 +23,17 @@ M.close_ui = function()
 end
 
 M.toggle_ui = function(opts)
-  require('muren.ui').toggle(opts)
+  require('muren.ui').toggle(get_opts(opts))
 end
 
 M.open_fresh_ui = function(opts)
-  opts = opts or {}
+  opts = get_opts(opts)
   opts.fresh = true
   require('muren.ui').open(opts)
 end
 
 M.open_unique_ui = function(opts)
-  require('muren.ui').open_unique(opts)
+  require('muren.ui').open_unique(get_opts(opts))
 end
 
 return M

--- a/lua/muren/api.lua
+++ b/lua/muren/api.lua
@@ -1,15 +1,7 @@
 local M = {}
 
-local get_range = function(opts)
-  local range
-  if opts.range == 2 then
-    range = {start = opts.line1, _end = opts.line2}
-  end
-  return range
-end
-
 M.open_ui = function(opts)
-  require('muren.ui').open({range = get_range(opts)})
+  require('muren.ui').open(opts)
 end
 
 M.close_ui = function()
@@ -17,15 +9,17 @@ M.close_ui = function()
 end
 
 M.toggle_ui = function(opts)
-  require('muren.ui').toggle({range = get_range(opts)})
+  require('muren.ui').toggle(opts)
 end
 
 M.open_fresh_ui = function(opts)
-  require('muren.ui').open({fresh = true, range = get_range(opts)})
+  opts = opts or {}
+  opts.fresh = true
+  require('muren.ui').open(opts)
 end
 
 M.open_unique_ui = function(opts)
-  require('muren.ui').open_unique({range = get_range(opts)})
+  require('muren.ui').open_unique(opts)
 end
 
 return M

--- a/lua/muren/options.lua
+++ b/lua/muren/options.lua
@@ -61,14 +61,6 @@ end
 
 M.values = {}
 
-local get_range = function(opts)
-  local range
-  if opts.range == 2 then
-    range = {start = opts.line1, _end = opts.line2}
-  end
-  return range
-end
-
 local check_anchor_value = function(anchor)
   local anchor_positions = require('muren').anchor_positions
   if anchor == 'center' or vim.tbl_contains(anchor_positions, anchor) then
@@ -90,7 +82,7 @@ M.populate = function(opts)
     end
   end
   local anchor = check_anchor_value(opts.anchor or M.default.anchor)
-  M.values.range = get_range(opts)
+  M.values.range = opts.range
   M.values.buffer = vim.api.nvim_get_current_buf()
   M.values.dir = vim.fn.getcwd()
   M.values.ft = vim.api.nvim_get_current_buf()

--- a/lua/muren/options.lua
+++ b/lua/muren/options.lua
@@ -27,11 +27,6 @@ M.default = {
   patterns_height = 10,
   options_width = 20,
   preview_height = 12,
-  -- window positions
-  vertical_anchor = "center", -- "top" | "center" | "bottom
-  horizontal_anchor = "center", -- "left" | "center" | "right"
-  vertical_offset = 0,
-  horizontal_offset = 0,
   -- options order in ui
   order = {
     'buffer',

--- a/lua/muren/options.lua
+++ b/lua/muren/options.lua
@@ -27,6 +27,11 @@ M.default = {
   patterns_height = 10,
   options_width = 20,
   preview_height = 12,
+  -- window positions
+  vertical_anchor = "center", -- "top" | "center" | "bottom
+  horizontal_anchor = "center", -- "left" | "center" | "right"
+  vertical_offset = 0,
+  horizontal_offset = 0,
   -- options order in ui
   order = {
     'buffer',

--- a/lua/muren/options.lua
+++ b/lua/muren/options.lua
@@ -27,6 +27,10 @@ M.default = {
   patterns_height = 10,
   options_width = 20,
   preview_height = 12,
+  -- ui position
+  anchor = 'center',
+  vertical_offset = 0,
+  horizontal_offset = 0,
   -- options order in ui
   order = {
     'buffer',
@@ -57,18 +61,45 @@ end
 
 M.values = {}
 
+local get_range = function(opts)
+  local range
+  if opts.range == 2 then
+    range = {start = opts.line1, _end = opts.line2}
+  end
+  return range
+end
+
+local check_anchor_value = function(anchor)
+  local anchor_positions = require('muren').anchor_positions
+  if anchor == 'center' or vim.tbl_contains(anchor_positions, anchor) then
+    return anchor
+  end
+  vim.notify('Invalid anchor value: \'' .. anchor .. '\'', 3, {title = 'Muren'})
+  return 'center'
+end
+
+local match_anchor_pattern = function(anchor, low, high, row_or_col)
+  local low_value, high_value = string.match(anchor, low), string.match(anchor, high)
+  return low_value or high_value or 'center_' .. row_or_col
+end
+
 M.populate = function(opts)
   for name, value in pairs(M.default) do
     if M.values[name] == nil or opts.fresh then
       M.values[name] = value
     end
   end
-  M.values.range = opts.range
+  local anchor = check_anchor_value(opts.anchor or M.default.anchor)
+  M.values.range = get_range(opts)
   M.values.buffer = vim.api.nvim_get_current_buf()
   M.values.dir = vim.fn.getcwd()
   M.values.ft = vim.api.nvim_get_current_buf()
   M.values.total_width = 2 * M.values.patterns_width + M.values.options_width + 4
   M.values.total_height = M.values.patterns_height + M.values.preview_height + 4
+  M.values.vertical_anchor = match_anchor_pattern(anchor, 'top', 'bottom', 'row')
+  M.values.horizontal_anchor = match_anchor_pattern(anchor, 'left', 'right', 'col')
+  M.values.vertical_offset = opts.vertical_offset or M.default.vertical_offset
+  M.values.horizontal_offset = opts.horizontal_offset or M.default.horizontal_offset
 end
 
 return M

--- a/lua/muren/ui.lua
+++ b/lua/muren/ui.lua
@@ -261,10 +261,10 @@ local make_ui_positions = function(opts)
     left = 0,
     right = (gwidth - opts.total_width),
   }
-  local v_anchor = anchors[opts.vertical_anchor] or anchors.center_row
-  local h_anchor = anchors[opts.horizontal_anchor] or anchors.center_col
-  local v_offset = (opts.vertical_offset or 0) * (v_anchor == anchors.bottom and -1 or 1)
-  local h_offset = (opts.horizontal_offset or 0) * (h_anchor == anchors.right and -1 or 1)
+
+  local v_anchor, h_anchor = anchors[opts.vertical_anchor], anchors[opts.horizontal_anchor]
+  local v_offset = opts.vertical_offset * (v_anchor == anchors.bottom and -1 or 1)
+  local h_offset = opts.horizontal_offset * (h_anchor == anchors.right and -1 or 1)
   local adjusted_row = math.max(anchors.top, math.min(v_anchor + v_offset, anchors.bottom))
   local adjusted_col = math.max(anchors.left, math.min(h_anchor + h_offset, anchors.right))
   return {

--- a/lua/muren/ui.lua
+++ b/lua/muren/ui.lua
@@ -269,6 +269,8 @@ local make_ui_positions = function()
       right = (gwidth - options.values.total_width),
     },
   }
+  horizontal_offset = horizontal_anchor == "right" and -horizontal_offset or horizontal_offset
+  vertical_offset = vertical_anchor == "bottom" and -vertical_offset or vertical_offset
   local adjusted_row = positions.row[vertical_anchor] + vertical_offset
   local adjusted_col = positions.col[horizontal_anchor] + horizontal_offset
   if adjusted_row < 0 then


### PR DESCRIPTION
Adds four new options to customize the position of the UI popup window(s):

- `vertical_anchor`
  - Options: `"top"`, `"center"`, `"bottom"`
  - Default: `"center"`
- `horizontal_anchor`
  - Options: `"left"`, `"center"`, `"right"`
  - Default: `"center"`
- `vertical_offset`
  - Default: 0
- `horizontal_offset`
  - Default: 0

The anchor and the offset values adjust the row and column position for each window (preview, patterns, replacements, options).

If the window would be out of bounds due to a combination of the anchor or offset opts and the overall size of the windows, the adjusted row/col positions of the UI are set to a max limit, placing them at their opposite anchor point.