### PR TITLE
Delete hidden buffers on UI close

### DIFF
--- a/lua/muren/ui.lua
+++ b/lua/muren/ui.lua
@@ -532,7 +532,8 @@ M.close = function()
   for _, win in pairs(wins) do
     if vim.api.nvim_win_is_valid(win) then
       noautocmd('WinClosed,CursorMoved', function()
-        vim.api.nvim_win_close(win, true)
+        local bufnr = vim.api.nvim_win_get_buf(win)
+        vim.api.nvim_buf_delete(bufnr, {force = true})
       end)
     end
   end


### PR DESCRIPTION
*Summary*: New UI buffers are created on each call of `MurenOpen` but seemingly not deleted on `MurenClose`, since the UI is closed by `nvim_win_close` . Should `MurenClose` call `nvim_buf_delete` instead?

Hello! I was wondering about Muren's buffer creation/deletion cycle. (I'm not well versed in Vim buffer fundamentals, so I hope this isn't a distraction). I have a function in my bufferline that keeps track of the loaded buffer count.

```lua
function()
  local listed_bufs = vim.api.nvim_list_bufs()
  local loaded_bufs = vim.tbl_filter(function(v)
    return vim.api.nvim_buf_is_loaded(v)
  end, listed_bufs)
  return #loaded_bufs
end,
```

During `MurenClose` each UI window is closed with `nvim_win_close` 


https://github.com/AckslD/muren.nvim/blob/e4558ab845f380915bb35b2fb7fea428b852cb8a/lua/muren/ui.lua#L532-L538

but, if my function is setup correctly, it appears the buffers are still in memory after closing. In the clip below, you can see the loaded buffer count creeping up by four on each open/close cycle

https://github.com/AckslD/muren.nvim/assets/23170004/20e14db1-ecc5-4a53-9739-13510f130876

Using `nvim_buf_delete` instead keeps the buffer count steady.

https://github.com/AckslD/muren.nvim/assets/23170004/8691f49c-c3ca-47be-ae96-4835aeb48300


Since `save_lines` is called right before closing the windows or deleting the buffers, subsequent calls of `MurenOpen` preserve the lines of previous ones.

https://github.com/AckslD/muren.nvim/assets/23170004/eeef81eb-f68b-462a-9682-537b82f4e621


Would this have some negative consequence on functionality?

I know that it's unlikely this would significantly affect performance, since no one is going to open/close Muren in a single session enough times for this to matter, but I thought I'd mention it (yes, I should have probably gone outdoors more on this Saturday). Hope all is well!