### PR TITLE
feat: add opts.replacements support to open_ui

### DIFF
--- a/lua/muren/ui.lua
+++ b/lua/muren/ui.lua
@@ -434,6 +434,10 @@ M.open = function(opts)
     vim.api.nvim_buf_set_lines(bufs.patterns, 0, -1, true, opts.patterns)
   elseif not opts.fresh then
     vim.api.nvim_buf_set_lines(bufs.patterns, 0, -1, true, last_lines.patterns or {})
+  end
+  if opts.replacements then
+    vim.api.nvim_buf_set_lines(bufs.replacements, 0, -1, true, opts.replacements)
+  elseif not opts.fresh then
     vim.api.nvim_buf_set_lines(bufs.replacements, 0, -1, true, last_lines.replacements or {})
   end
   populate_options_buf()


### PR DESCRIPTION
  ## Summary
  Adds `opts.replacements` parameter to `open_ui()`, mirroring existing `opts.patterns` behavior.

  ## Motivation
  Enables programmatic pre-population of both patterns and replacements buffers, useful for integrations that want to open muren with specific search/replace pairs already filled in.

  ## Changes
  - `lua/muren/ui.lua`: Add conditional logic for `opts.replacements` matching the `opts.patterns` pattern

  ## Testing
  Tested locally by calling:
  ```lua
  require('muren.api').open_ui({
    patterns = { 'foo', 'bar' },
    replacements = { 'baz', 'qux' },
  })
  ```
  Both buffers populate correctly and replacements work as expected.